### PR TITLE
Fix Facebook not recognizing the set app_id

### DIFF
--- a/admin/partials/wp-og-admin-display.php
+++ b/admin/partials/wp-og-admin-display.php
@@ -67,7 +67,7 @@
                         </tr>
                         <tr valign="top">
                             <th scope="row">
-                                <label for="og-app_id"><?php _e('App ID', 'wp-og'); ?> – <small>og:app_id</small></label>
+                                <label for="og-app_id"><?php _e('App ID', 'wp-og'); ?> – <small>fb:app_id</small></label>
                             </th>
                             <td>
                                 <input type="text" name="og-app_id" id="og-app_id" value="<?php echo esc_attr( get_option('og-app_id') ); ?>" class="regular-text"/>

--- a/public/class-wp-og-public.php
+++ b/public/class-wp-og-public.php
@@ -77,7 +77,7 @@ class WP_OG_Public {
 		// Only show app_id if defined
 		$app_id = get_option('og-app_id');
 		if( !empty($app_id) )
-			echo $this->generate_og_tag('og:app_id', $app_id);
+			echo $this->generate_og_tag('fb:app_id', $app_id);
 	}
 
 	/**


### PR DESCRIPTION
The Facebook Sharing Debugger would still warn for "Share App ID Missing" even after setting the app id in the plugin settings, as Facebook only uses the fb:app_id property instead of og:app_id